### PR TITLE
Update [...nextauth].ts

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -61,6 +61,14 @@ if (process.env.AZURE_AD_CLIENT_ID) {
       clientId: process.env.AZURE_AD_CLIENT_ID!,
       clientSecret: process.env.AZURE_AD_CLIENT_SECRET!,
       tenantId: process.env.AZURE_AD_TENANT_ID,
+      profile(profile) {
+        return {
+          id: profile.oid,
+          name: profile.name,
+          email: profile.email,
+          image: null
+        }
+      }
     }),
   );
 }


### PR DESCRIPTION
[next-auth][error][OAUTH_PARSE_PROFILE_ERROR] 
https://next-auth.js.org/errors#oauth_parse_profile_error fetch failed {
  error: {
    message: 'fetch failed',
    stack: 'TypeError: fetch failed\n' +
      '    at Object.fetch (node:internal/deps/undici/undici:11457:11)\n' +
      '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
      '    at async Object.profile (/app/node_modules/next-auth/providers/azure-ad.js:27:24)\n' +
      '    at async getProfile (/app/node_modules/next-auth/core/lib/oauth/callback.js:162:21)\n' +
      '    at async oAuthCallback (/app/node_modules/next-auth/core/lib/oauth/callback.js:136:27)\n' +
      '    at async Object.callback (/app/node_modules/next-auth/core/routes/callback.js:52:11)\n' +
      '    at async AuthHandler (/app/node_modules/next-auth/core/index.js:208:28)\n' +
      '    at async NextAuthApiHandler (/app/node_modules/next-auth/next/index.js:22:19)\n' +
      '    at async NextAuth._args$ (/app/node_modules/next-auth/next/index.js:106:14)',
    name: 'TypeError'
  },

It seems like profile was not defined, next-auth was expecting Azure-AD to return profile information together with image, however, Azure does not return image at all, so it had to be set to null.